### PR TITLE
chore: Dependabotのtarget-branchをdevelopmentに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  target-branch: development
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  target-branch: development


### PR DESCRIPTION
## 概要

Dependabotが作成する自動PRのターゲットブランチをdevelopmentに変更します。

## 変更内容

- `.github/dependabot.yml` に `target-branch: development` を追加
- bundlerとgithub-actionsの両方のエコシステムに適用
- main > development > featureのブランチ構成に合わせた設定

これにより、Dependabotの自動PRがdevelopmentブランチに向けて作成されるようになります。

### スクリーンショット

N/A（設定ファイルの変更のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)